### PR TITLE
Nondeterminism strategy support for reachability search

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -46,10 +46,15 @@ int main(int argc, char** argv) {
     TTAParser ttaParser{};
     TTA t = ttaParser.ParseFromFilePath(config["input"].as_string());
 
+    // What nondeterminism strategy should we use
+    auto strategy = nondeterminism_strategy_t::PICK_FIRST;
+    if(config["nondeterminism-strategy"])
+        strategy = (nondeterminism_strategy_t)config["nondeterminism-strategy"].as_integer();
+
     // Parse the queries
     if(config["query"]) {
         auto queryList = CTLQueryParser::ParseQueriesFile(config["query"].as_string(), t);
-        ReachabilitySearcher s{queryList, t}; s.Search();
+        ReachabilitySearcher s{queryList, t}; s.Search(strategy);
         return 0;
     }
 

--- a/src/verifier/ReachabilitySearcher.h
+++ b/src/verifier/ReachabilitySearcher.h
@@ -41,15 +41,16 @@ class ReachabilitySearcher {
     std::vector<QueryResultPair> query_results;
 public:
     ReachabilitySearcher(const std::vector<const Query*>& queries, const TTA& initialState);
-    inline bool Search() { return ForwardReachabilitySearch(); }
+    inline bool Search(const nondeterminism_strategy_t& strategy = nondeterminism_strategy_t::PICK_FIRST) { return ForwardReachabilitySearch(strategy); }
     void AddToWaitingList(const TTA& state, const std::vector<TTA::StateChange>& statechanges, bool justTocked);
 private:
     static bool IsSearchStateTockable(const SearchState& state);
     bool AreQueriesAnswered(const std::vector<QueryResultPair>& qres);
     bool IsQuerySatisfied(const Query& query, const TTA& state);
     void AreQueriesSatisfied(std::vector<QueryResultPair>& queries, const TTA& state);
-    bool ForwardReachabilitySearch();
+    bool ForwardReachabilitySearch(const nondeterminism_strategy_t& strategy);
     void PrintResults(const std::vector<QueryResultPair>& results);
+    StateList::iterator PickStateFromWaitingList(const nondeterminism_strategy_t& strategy);
 };
 
 #endif //MAVE_REACHABILITYSEARCHER_H


### PR DESCRIPTION
This is mostly useful if you want to do random search through the statespace instead of the default BFS.