### PR TITLE
Safety Query Support

### DIFF
--- a/src/verifier/ReachabilitySearcher.cpp
+++ b/src/verifier/ReachabilitySearcher.cpp
@@ -68,7 +68,7 @@ bool ReachabilitySearcher::IsQuerySatisfied(const Query& query, const TTA &state
     if(query.root.type == NodeType_t::Forall && query.children.begin()->root.type == NodeType_t::Globally) {
         auto invertedQ = Query(ASTNode{NodeType_t::Negation, "!"});
         invertedQ.insert(query);
-        return !IsQuerySatisfiedHelper(invertedQ, state);
+        return IsQuerySatisfiedHelper(invertedQ, state);
     }
     if(query.root.type != NodeType_t::Exists) {
         spdlog::critical("Only reachability queries are supported right now, sorry.");

--- a/src/verifier/ReachabilitySearcher.cpp
+++ b/src/verifier/ReachabilitySearcher.cpp
@@ -65,6 +65,11 @@ bool IsQuerySatisfiedHelper(const Query& query, const TTA& state) {
 }
 
 bool ReachabilitySearcher::IsQuerySatisfied(const Query& query, const TTA &state) {
+    if(query.root.type == NodeType_t::Forall && query.children.begin()->root.type == NodeType_t::Globally) {
+        auto invertedQ = Query(ASTNode{NodeType_t::Negation, "!"});
+        invertedQ.insert(query);
+        return !IsQuerySatisfiedHelper(invertedQ, state);
+    }
     if(query.root.type != NodeType_t::Exists) {
         spdlog::critical("Only reachability queries are supported right now, sorry.");
         return false;


### PR DESCRIPTION
This is a fairly simple patch. A G x is the same as the inverted result of E F not x

The output printing is the primary roadblock here 