### PR TITLE
Patch/interestingness on external vars

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
         return config.GetStatusCode();
     }
     if(config["verbosity"])
-        spdlog::set_level(static_cast<spdlog::level::level_enum>(6-config["verbosity"].as_integer()));
+        spdlog::set_level(static_cast<spdlog::level::level_enum>(SPDLOG_LEVEL_OFF-config["verbosity"].as_integer()));
     else
         spdlog::set_level(spdlog::level::level_enum::warn);
 

--- a/src/model_parsers/TTAParser.cpp
+++ b/src/model_parsers/TTAParser.cpp
@@ -61,7 +61,8 @@ std::vector<TTAParser::SymbolExternalPair> TTAParser::ParsePartsFiles(const std:
     for (const auto & entry : std::filesystem::directory_iterator(path)) {
         // Filter over ONLY the .parts files.
         auto isEntryPartsFile = entry.is_regular_file() && entry.path().string().find(".parts") != std::string::npos;
-        if(!isEntryPartsFile) continue;
+        if(!isEntryPartsFile)
+            continue;
         auto parts = ParsePartsFile(entry.path().string());
         totalParts.insert(totalParts.end(), parts.begin(), parts.end());
     }
@@ -306,9 +307,10 @@ TTAParser::ConvertEdgeListToEdgeMap(const std::vector<TTAIR_t::Edge> &edgeList, 
 }
 extern void SetVerbosity(unsigned int level);
 TTA::GuardCollection TTAParser::ParseExternalVariablesUsedInGuardExpression(const std::string& guardExpression, const TTA::ExternalSymbolMap& externalSymbolMap) {
+    if(guardExpression.empty())
+        return {};
     SetVerbosity(0); // TODO: We should really do this properly
-    if(guardExpression.empty()) return {};
-    auto expressions = regex_split(guardExpression, "&&|\\|\\||and|or");
+    auto expressions = regex_split(guardExpression, "&&|\\|\\|");
     TTA::GuardCollection coll = {};
     bool doesExpressionContainExternalVariableBool = false;
     auto doesExpressionContainExternalVariable = [&externalSymbolMap, &doesExpressionContainExternalVariableBool](const ASTNode& n) {
@@ -321,7 +323,8 @@ TTA::GuardCollection TTAParser::ParseExternalVariablesUsedInGuardExpression(cons
     for(auto& expr : expressions) {
         // TODO: Parentheses fuck everything up. It should be fixed.
         auto ge = ParseGuardExpression(expr);
-        if(!ge) continue;
+        if(!ge)
+            continue;
         ge->tree_apply(doesExpressionContainExternalVariable);
         if(doesExpressionContainExternalVariableBool) {
             // Extract the expression only. TODO: Write a more flexible parser

--- a/src/runtime/TTA.h
+++ b/src/runtime/TTA.h
@@ -53,7 +53,7 @@ struct TTA {
         std::string guardExpression;
         GuardCollection externalGuardCollection;
         std::vector<UpdateExpression> updateExpressions;
-        bool ContainsExternalChecks() const { return ! externalGuardCollection.empty(); }
+        [[nodiscard]] bool ContainsExternalChecks() const { return ! externalGuardCollection.empty(); }
     };
     struct Component {
         // TODO: I dont like storing full strings.


### PR DESCRIPTION
## Changes:
 - Fixed an issue where guard like "my_var && my_other_var" would not work during interestingness check
 - Removed `and|or` part of query syntax, since it collided with variable names such as `selector` and `brand_name` etc.