### PR TITLE
Patch/multimap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ build/
 
 **/.DS_Store
 test/**/results.txt
+
+bin/

--- a/src/cli/CLIConfig.cpp
+++ b/src/cli/CLIConfig.cpp
@@ -57,6 +57,9 @@ CLIConfig::CLIConfig() {
             { option_requirement::Optional,
                     {"explosion-limit", 'l', argument_requirement::REQUIRE_ARG,
                             "[INTEGER] Sets a limit on what the maximum amount of interesting changes. -1 means no limit. Default is -1. NB! This will result in incorrect answers"} },
+            { option_requirement::Optional,
+                    {"notrace", 'c', argument_requirement::NO_ARG,
+                            "Disable print of traces to stdout"} },
     };
     status_code = EXIT_SUCCESS;
 }

--- a/src/verifier/ReachabilitySearcher.cpp
+++ b/src/verifier/ReachabilitySearcher.cpp
@@ -83,6 +83,7 @@ void ReachabilitySearcher::AreQueriesSatisfied(std::vector<QueryResultPair>& que
             query.answer = IsQuerySatisfied(*query.query, state);
             if (query.answer) {
                 query.acceptingStateHash = state_hash;
+                query.acceptingState.tta = state; // TODO: This is terrible
                 auto ss = ConvertASTToString(*query.query);
                 spdlog::info("Query '{0}' is satisfied!", ss);
                 spdlog::debug("Query '{0}' was satisfied in state: \n{1}", ss, state.GetCurrentStateString());

--- a/src/verifier/ReachabilitySearcher.h
+++ b/src/verifier/ReachabilitySearcher.h
@@ -22,16 +22,22 @@
 #include <verifier/query_parsing/CTLQueryParser.h>
 #include <runtime/TTA.h>
 
-struct QueryResultPair {
-    bool answer;
-    const Query* query;
-    size_t acceptingStateHash;
-};
+#include <utility>
 
 struct SearchState {
     TTA tta;
     size_t prevStateHash;
     bool justTocked;
+    bool operator==(const SearchState& other);
+};
+
+struct QueryResultPair {
+    bool answer;
+    const Query* query;
+    size_t acceptingStateHash;
+    SearchState acceptingState;
+    QueryResultPair(bool _answer, const Query* _query, size_t _acceptingStateHash, SearchState _acceptingState)
+     : answer{_answer}, query{_query}, acceptingStateHash{_acceptingStateHash}, acceptingState{std::move(_acceptingState)} {}
 };
 
 class ReachabilitySearcher {

--- a/src/verifier/ReachabilitySearcher.h
+++ b/src/verifier/ReachabilitySearcher.h
@@ -35,7 +35,7 @@ struct SearchState {
 };
 
 class ReachabilitySearcher {
-    using StateList = std::unordered_map<size_t, SearchState>;
+    using StateList = std::unordered_multimap<size_t, SearchState>;
     StateList Passed;
     StateList Waiting;
     std::vector<QueryResultPair> query_results;


### PR DESCRIPTION
## Merge #29 first

## Changes:
 - Changed Waiting and Passed lists to be `std::multimap`'s instead of just `std::map`'s, so we now also store states with colliding hashes. 
 - Added warnings when hash collisions has happened in a query result, the current structure does not allow handling of the collisions 

