### PR TITLE
Fix nondeterminism strategy code

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,7 +79,7 @@ jobs:
         working-directory: ${{github.workspace}}/build
         shell: bash
         # Execute the build.  You can specify a specific target with "--target <NAME>"
-        run: cmake --build . --config $BUILD_TYPE -j$(nproc)
+        run: cmake --build . --config $BUILD_TYPE -j 8
   verification-tests:
     runs-on: ubuntu-latest
     needs: build-linux

--- a/src/model_parsers/TTAParser.cpp
+++ b/src/model_parsers/TTAParser.cpp
@@ -258,7 +258,7 @@ TTA::SymbolMap TTAParser::ConvertSymbolListToSymbolMap(const std::vector<TTAIR_t
     std::for_each(symbolList.begin(), symbolList.end(), [&map] (auto& symbol) {
         std::visit(overload(
                 [&](const int& value)            { map[symbol.identifier] = static_cast<int>(value); },
-                [&](const long& value)           { map[symbol.identifier] = static_cast<long>(value); },
+                [&](const long& value)           { map[symbol.identifier] = static_cast<int64_t>(value); },
                 [&](const float& value)          { map[symbol.identifier] = static_cast<float>(value); },
                 [&](const bool& value)           { map[symbol.identifier] = static_cast<bool>(value); },
                 [&](const TTATimerSymbol& value) { map[symbol.identifier] = packToken(value.current_value, PACK_IS_TIMER); },

--- a/src/verifier/ReachabilitySearcher.cpp
+++ b/src/verifier/ReachabilitySearcher.cpp
@@ -212,19 +212,27 @@ bool ReachabilitySearcher::IsSearchStateTockable(const SearchState& state) {
 }
 
 ReachabilitySearcher::StateList::iterator ReachabilitySearcher::PickStateFromWaitingList(const nondeterminism_strategy_t& strategy) {
-    if(Waiting.empty()) return Waiting.end();
-    if(Waiting.size() == 1) return Waiting.begin();
+    if(Waiting.empty())
+        return Waiting.end();
+    if(Waiting.size() == 1)
+        return Waiting.begin();
     switch (strategy) {
         case nondeterminism_strategy_t::PANIC:
             throw std::logic_error("Panicking on nondeterminism");
         case nondeterminism_strategy_t::VERIFICATION:
         case nondeterminism_strategy_t::PICK_FIRST:
-        case nondeterminism_strategy_t::PICK_LAST:
-            return Waiting.begin(); // There's not a concept of "last" or "first" in a hashmap
+            return Waiting.begin();
+        case nondeterminism_strategy_t::PICK_LAST: {
+            auto begin = Waiting.begin();
+            for (auto i = 0; i < Waiting.size(); i++)
+                begin++;
+            return begin;
+        }
         case nondeterminism_strategy_t::PICK_RANDOM:
-            auto randomPick = rand() % Waiting.size()-1;
+            auto randomPick = rand() % Waiting.size();
             auto picked = Waiting.begin();
-            for(int i = 0; i < randomPick; i++) picked++;
+            for(int i = 0; i < randomPick; i++)
+                picked++;
             return picked;
     }
     return Waiting.end();

--- a/src/verifier/TTASuccessorGenerator.cpp
+++ b/src/verifier/TTASuccessorGenerator.cpp
@@ -106,7 +106,7 @@ using VariableValueVector = std::vector<std::pair<std::string, TTASymbol_t>>;
 void AssignVariable(TTA::SymbolMap& outputMap, const TTA::SymbolMap& currentValues, const std::string &varname, const TTASymbol_t &newValue) {
     std::visit(overload(
             [&](const int& v)            { outputMap.map()[varname] = v; },
-            [&](const long& v)           { outputMap.map()[varname] = v; },
+            [&](const long& v)           { outputMap.map()[varname] = static_cast<int64_t>(v); },
             [&](const float& v)          { outputMap.map()[varname] = v; },
             [&](const bool& v)           { outputMap.map()[varname] = v; },
             [&](const TTATimerSymbol& v) {


### PR DESCRIPTION
# Fixes
 - PICK_FIRST and PICK_LAST are excactly the same behavior. Even though there's no "order" in an unordered_map, they should still provide different results.
 - PICK_RANDOM would consistently pick one choice if two was available (off-by-one error)
 - CI for windows platforms should compile threaded