### PR TITLE
Patch/bug hunting

### DIFF
--- a/src/runtime/TTA.cpp
+++ b/src/runtime/TTA.cpp
@@ -178,6 +178,8 @@ std::optional<StateMultiChoice> TTA::GetChangesFromEdge(const TTA::Edge& choice,
     changes.component = currentComponent;
     bool DoesUpdateInfluenceOverlap = AccumulateUpdateInfluences(choice, changes.symbolsToChange, overlappingComponents, currentComponent);
     outInfluenceOverlap |= DoesUpdateInfluenceOverlap;
+    if(DoesUpdateInfluenceOverlap)
+        return {};
 
     for(auto& symbolChange : changes.symbolsToChange)
         changes.symbolChanges.push_back(symbolChange.second);
@@ -200,9 +202,9 @@ void TTA::WarnAboutComponentOverlap(component_overlap_t& overlappingComponents) 
     if(overlapping_errors.empty())
         return;
 
-    spdlog::warn("Overlapping Updates:");
+    spdlog::info("Overlapping Updates:");
     for(auto& err : overlapping_errors)
-        spdlog::warn(err);
+        spdlog::info(err);
 }
 
 TokenMap TTA::GetSymbolChangesAsMap(std::vector<UpdateExpression> &symbolChanges) const {
@@ -384,7 +386,7 @@ bool TTA::AccumulateUpdateInfluences(const TTA::Edge& pickedEdge, std::multimap<
             for(auto iter = range.first; iter != range.second; iter++) {
                 if(iter->second.componentName == currentComponent)
                     continue;
-                // TODO: Check for Indempotence!
+                // TODO: Check for Idempotence!
                 spdlog::debug("Overlapping update influence on evaluation of update on edge {0} --> {1}. "
                               "Variable '{2}' is already being written to in this tick! - For more info, run with higher verbosity",
                               TTAResugarizer::Resugar(pickedEdge.sourceLocation.identifier),

--- a/src/runtime/TTA.cpp
+++ b/src/runtime/TTA.cpp
@@ -230,9 +230,9 @@ void TTA::WarnAboutComponentOverlap(component_overlap_t& overlappingComponents) 
     if(overlapping_errors.empty())
         return;
 
-    spdlog::info("Overlapping Updates:");
+    spdlog::trace("Overlapping Updates:");
     for(auto& err : overlapping_errors)
-        spdlog::info(err);
+        spdlog::trace(err);
 }
 
 TokenMap TTA::GetSymbolChangesAsMap(std::vector<UpdateExpression> &symbolChanges) const {

--- a/src/runtime/TTA.h
+++ b/src/runtime/TTA.h
@@ -72,7 +72,12 @@ struct TTA {
 
         std::vector<Edge> GetEnabledEdges(const SymbolMap& symbolMap) const;
     };
+
+#ifndef NDEBUG
+    using ComponentMap = std::map<std::string, Component>;
+#else
     using ComponentMap = std::unordered_map<std::string, Component>;
+#endif
     using ComponentLocationMap = std::unordered_map<std::string, Location>;
     struct StateChange {
         ComponentLocationMap componentLocations;

--- a/src/runtime/TTASymbol.h
+++ b/src/runtime/TTASymbol.h
@@ -21,6 +21,7 @@
 #ifndef AALTITOAD_TTASYMBOL_H
 #define AALTITOAD_TTASYMBOL_H
 #include <aaltitoadpch.h>
+#include "extensions/overload"
 
 struct TTATimerSymbol {
     float current_value;
@@ -38,6 +39,9 @@ using TTASymbol_t = std::variant<
         TTATimerSymbol,
         std::string
 >;
+
+bool operator==(const TTASymbol_t&, const TTASymbol_t&);
+bool operator!=(const TTASymbol_t&, const TTASymbol_t&);
 
 TTASymbol_t TTASymbolValueFromTypeAndValueStrings(const std::string& typestr, const std::string& valuestr);
 TTASymbol_t TTASymbolTypeFromString(const std::string& typestr);

--- a/src/verifier/ReachabilitySearcher.cpp
+++ b/src/verifier/ReachabilitySearcher.cpp
@@ -39,13 +39,11 @@ bool IsQuerySatisfiedHelper(const Query& query, const TTA& state) {
         case NodeType_t::CompEq:
         case NodeType_t::CompGreater:
         case NodeType_t::CompGreaterEq: {
-            std::string exprstring{}; // This string can technically be precompiled.
-            query.children[0].tree_apply([&exprstring]( const ASTNode& node ){ exprstring += node.token; });
-            exprstring += query.root.token;
-            query.children[1].tree_apply([&exprstring]( const ASTNode& node ){ exprstring += node.token; });
-            spdlog::debug("Assembled expression '{0}'", exprstring);
-            calculator c(exprstring.c_str());
-            return c.eval(state.GetSymbols()).asBool();
+            std::stringstream exprstring{}; // This string can technically be precompiled.
+            query.children[0].tree_apply([&exprstring]( const ASTNode& node ){ exprstring << node.token; });
+            exprstring << query.root.token;
+            query.children[1].tree_apply([&exprstring]( const ASTNode& node ){ exprstring << node.token; });
+            return calculator(exprstring.str().c_str()).eval(state.GetSymbols()).asBool();
         }
         case NodeType_t::SubExpr:
         case NodeType_t::Finally:
@@ -66,9 +64,7 @@ bool IsQuerySatisfiedHelper(const Query& query, const TTA& state) {
 
 bool ReachabilitySearcher::IsQuerySatisfied(const Query& query, const TTA &state) {
     if(query.root.type == NodeType_t::Forall && query.children.begin()->root.type == NodeType_t::Globally) {
-        auto invertedQ = Query(ASTNode{NodeType_t::Negation, "!"});
-        invertedQ.insert(query);
-        return IsQuerySatisfiedHelper(invertedQ, state);
+        return !IsQuerySatisfiedHelper(query, state);
     }
     if(query.root.type != NodeType_t::Exists) {
         spdlog::critical("Only reachability queries are supported right now, sorry.");
@@ -96,17 +92,22 @@ void ReachabilitySearcher::OutputResults(const std::vector<QueryResultPair>& res
     if(CLIConfig::getInstance()["output"]) {
         std::ofstream outputFile{CLIConfig::getInstance()["output"].as_string(), std::ofstream::trunc};
         for(auto& r : results) {
-            outputFile << ConvertASTToString(*r.query) << " : " << std::boolalpha << r.answer << "\n";
+            auto answer = r.query->root.type == NodeType_t::Forall && r.query->children[0].root.type == NodeType_t::Globally ? !r.answer : r.answer;
+            outputFile << ConvertASTToString(*r.query) << " : " << std::boolalpha << answer << "\n";
         }
     }
 }
 
-void ReachabilitySearcher::PrintResults(const std::vector<QueryResultPair>& results) {
+auto ReachabilitySearcher::PrintResults(const std::vector<QueryResultPair>& results) -> int {
     OutputResults(results);
+    auto acceptedResults = 0;
     spdlog::info("==== QUERY RESULTS ====");
     for(const auto& r : results) {
         spdlog::info("===================="); // Delimiter to make it easier to read
-        spdlog::info("{0} : {1}", ConvertASTToString(*r.query), r.answer);
+        auto answer = r.query->root.type == NodeType_t::Forall && r.query->children[0].root.type == NodeType_t::Globally ? !r.answer : r.answer;
+        if(answer)
+            acceptedResults++;
+        spdlog::info("{0} : {1}", ConvertASTToString(*r.query), answer);
         auto stateHash = r.acceptingStateHash;
         auto state = r.acceptingState;
         std::vector<std::string> trace{};
@@ -135,6 +136,10 @@ void ReachabilitySearcher::PrintResults(const std::vector<QueryResultPair>& resu
                 break;
             }
         }
+        if(trace.empty()) {
+            spdlog::info("No trace available");
+            continue;
+        }
         spdlog::info("Trace:");
         std::reverse(trace.begin(), trace.end());
         printf("[\n");
@@ -142,6 +147,7 @@ void ReachabilitySearcher::PrintResults(const std::vector<QueryResultPair>& resu
             printf("%s,\n", stateStr.c_str());
         printf("]\n");
     }
+    return acceptedResults;
 }
 
 auto debug_int_as_hex_str(size_t v) {
@@ -175,7 +181,7 @@ void debug_print_passed_list(const ReachabilitySearcher& r) {
     spdlog::trace("====/PASSED LIST ====");
 }
 
-void debug_cleanup_waiting_list(ReachabilitySearcher& s, size_t curstatehash, const SearchState& state) {
+void cleanup_waiting_list(ReachabilitySearcher& s, size_t curstatehash, const SearchState& state) {
     bool found;
     do {
         found = false;
@@ -205,11 +211,11 @@ bool ReachabilitySearcher::ForwardReachabilitySearch(const nondeterminism_strate
         AreQueriesSatisfied(query_results, state.tta, curstatehash);
         if(AreQueriesAnswered(query_results)) {
             Passed.emplace(std::make_pair(curstatehash, state));
-            if(!CLIConfig::getInstance()["notrace"])
-                PrintResults(query_results);
-            spdlog::info("Found a positive result after searching: {0} states", Passed.size());
             if(CLIConfig::getInstance()["verbosity"] && CLIConfig::getInstance()["verbosity"].as_integer() >= 6)
                 debug_print_passed_list(*this);
+            spdlog::info("Found a positive result after searching: {0} states", Passed.size());
+            if(!CLIConfig::getInstance()["notrace"])
+                return query_results.size() - PrintResults(query_results) == 0;
             return true; // All the queries has been reached
         }
         // If the state is interesting, apply tock changes
@@ -222,16 +228,15 @@ bool ReachabilitySearcher::ForwardReachabilitySearch(const nondeterminism_strate
         AddToWaitingList(state.tta, allTickStateChanges, false, curstatehash);
 
         Passed.emplace(std::make_pair(curstatehash, state));
-        auto vs = debug_get_symbol_map_string_representation(state.tta.symbols);
-        // spdlog::warn("New amount of states: {0}", allTickStateChanges.size());
-        debug_cleanup_waiting_list(*this, curstatehash, state);
+
+        cleanup_waiting_list(*this, curstatehash, state);
         stateit = PickStateFromWaitingList(strategy);
     }
-    if(!CLIConfig::getInstance()["notrace"])
-        PrintResults(query_results);
     spdlog::info("Found a negative result after searching: {0} states", Passed.size());
     if(CLIConfig::getInstance()["verbosity"].as_integer() >= 6)
         debug_print_passed_list(*this);
+    if(!CLIConfig::getInstance()["notrace"])
+        return query_results.size() - PrintResults(query_results) == 0;
     return false;
 }
 

--- a/src/verifier/ReachabilitySearcher.cpp
+++ b/src/verifier/ReachabilitySearcher.cpp
@@ -137,7 +137,7 @@ void ReachabilitySearcher::PrintResults(const std::vector<QueryResultPair>& resu
         }
         spdlog::info("Trace:");
         std::reverse(trace.begin(), trace.end());
-        printf("[");
+        printf("[\n");
         for(auto& stateStr : trace)
             printf("%s,\n", stateStr.c_str());
         printf("]\n");
@@ -254,8 +254,10 @@ void ReachabilitySearcher::AddToWaitingList(const TTA &state, const std::vector<
             auto nstate = state << change;
             auto nstatehash = nstate.GetCurrentStateHash();
             if (Passed.find(nstatehash) == Passed.end()) {
-                if (nstatehash == state_hash)
-                    spdlog::warn("Colliding state hashes!");
+                if (nstatehash == state_hash) {
+                    spdlog::warn("Recursive state hashes!");
+                    continue;
+                }
                 Waiting.emplace(std::make_pair(nstatehash, SearchState{nstate, state_hash, justTocked}));
             }
         }
@@ -270,8 +272,10 @@ void ReachabilitySearcher::AddToWaitingList(const TTA &state, const std::vector<
             auto nstate = baseChanges << *it;
             auto nstatehash = nstate.GetCurrentStateHash();
             if (Passed.find(nstatehash) == Passed.end()) {
-                if (nstatehash == state_hash)
-                    spdlog::warn("Colliding state hashes!");
+                if (nstatehash == state_hash) {
+                    spdlog::warn("Recursive state hashes!");
+                    continue;
+                }
                 Waiting.emplace(std::make_pair(nstatehash, SearchState{nstate, state_hash, justTocked}));
             }
         }

--- a/src/verifier/ReachabilitySearcher.h
+++ b/src/verifier/ReachabilitySearcher.h
@@ -55,7 +55,7 @@ private:
     bool IsQuerySatisfied(const Query& query, const TTA& state);
     void AreQueriesSatisfied(std::vector<QueryResultPair>& queries, const TTA& state, size_t state_hash);
     bool ForwardReachabilitySearch(const nondeterminism_strategy_t& strategy);
-    void PrintResults(const std::vector<QueryResultPair>& results);
+    auto PrintResults(const std::vector<QueryResultPair>& results) -> int;
     void OutputResults(const std::vector<QueryResultPair>& results);
     StateList::iterator PickStateFromWaitingList(const nondeterminism_strategy_t& strategy);
 };

--- a/test/verification/fischer-2/Main€FischerAð1đ.json
+++ b/test/verification/fischer-2/Main€FischerAð1đ.json
@@ -1,1 +1,168 @@
-{"name":"Main€FischerAð1đ","declarations":"","locations":[{"id":"Main€FischerAð1đ€L3","nickname":"","invariant":"","type":"NORMAL","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0},{"id":"Main€FischerAð1đ€L4","nickname":"","invariant":"","type":"NORMAL","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0},{"id":"Main€FischerAð1đ€L5","nickname":"","invariant":"","type":"NORMAL","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0},{"id":"Main€FischerAð1đ€L6","nickname":"","invariant":"","type":"NORMAL","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0}],"initial_location": {"id":"Main€FischerAð1đ€L2","nickname":"","invariant":"","type":"INITIAL","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0},"final_location": {"id":"Main€FischerAð1đ€L8","nickname":"","invariant":"","type":"FINAl","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0},"jorks":[],"sub_components": [],"edges": [{"source_location": "Main€FischerAð1đ€L2","target_location": "Main€FischerAð1đ€L3","select":"","guard":"true","update":"","sync":"","nails": []},{"source_location": "Main€FischerAð1đ€L3","target_location": "Main€FischerAð1đ€L4","select":"","guard":"pubid == 0","update":"x :=  0;","sync":"","nails": []},{"source_location": "Main€FischerAð1đ€L5","target_location": "Main€FischerAð1đ€L6","select":"","guard":"pubid == 1","update":"counter :=  counter +1 ;x :=  0;","sync":"","nails": []},{"source_location": "Main€FischerAð1đ€L4","target_location": "Main€FischerAð1đ€L5","select":"","guard":"x <= k","update":"pubid :=  1;","sync":"","nails": []},{"source_location": "Main€FischerAð1đ€L5","target_location": "Main€FischerAð1đ€L4","select":"","guard":"x > k && pubid != 1","update":"x :=  0;","sync":"","nails": []},{"source_location": "Main€FischerAð1đ€L6","target_location": "Main€FischerAð1đ€L3","select":"","guard":"true","update":"pubid :=  0 ;counter :=  counter -1;","sync":"","nails": []}],"main":false,"description": "AUTOMATICALLY GENERATED. DO NOT USE THIS","x":0.0,"y":0.0,"width":0.0,"height":0.0,"color":"7","include_in_periodic_check":false}
+{
+    "name": "Main€FischerAð1đ",
+    "declarations": "",
+    "locations":
+    [
+        {
+            "id": "Main€FischerAð1đ€L3",
+            "nickname": "",
+            "invariant": "",
+            "type": "NORMAL",
+            "urgency": "NORMAL",
+            "x": 0.0,
+            "y": 0.0,
+            "color": "7",
+            "nickname_x": 0.0,
+            "nickname_y": 0.0,
+            "invariant_x": 0.0,
+            "invariant_y": 0.0
+        },
+        {
+            "id": "Main€FischerAð1đ€L4",
+            "nickname": "",
+            "invariant": "",
+            "type": "NORMAL",
+            "urgency": "NORMAL",
+            "x": 0.0,
+            "y": 0.0,
+            "color": "7",
+            "nickname_x": 0.0,
+            "nickname_y": 0.0,
+            "invariant_x": 0.0,
+            "invariant_y": 0.0
+        },
+        {
+            "id": "Main€FischerAð1đ€L5",
+            "nickname": "",
+            "invariant": "",
+            "type": "NORMAL",
+            "urgency": "NORMAL",
+            "x": 0.0,
+            "y": 0.0,
+            "color": "7",
+            "nickname_x": 0.0,
+            "nickname_y": 0.0,
+            "invariant_x": 0.0,
+            "invariant_y": 0.0
+        },
+        {
+            "id": "Main€FischerAð1đ€L6",
+            "nickname": "",
+            "invariant": "",
+            "type": "NORMAL",
+            "urgency": "NORMAL",
+            "x": 0.0,
+            "y": 0.0,
+            "color": "7",
+            "nickname_x": 0.0,
+            "nickname_y": 0.0,
+            "invariant_x": 0.0,
+            "invariant_y": 0.0
+        }
+    ],
+    "initial_location":
+    {
+        "id": "Main€FischerAð1đ€L2",
+        "nickname": "",
+        "invariant": "",
+        "type": "INITIAL",
+        "urgency": "NORMAL",
+        "x": 0.0,
+        "y": 0.0,
+        "color": "7",
+        "nickname_x": 0.0,
+        "nickname_y": 0.0,
+        "invariant_x": 0.0,
+        "invariant_y": 0.0
+    },
+    "final_location":
+    {
+        "id": "Main€FischerAð1đ€L8",
+        "nickname": "",
+        "invariant": "",
+        "type": "FINAl",
+        "urgency": "NORMAL",
+        "x": 0.0,
+        "y": 0.0,
+        "color": "7",
+        "nickname_x": 0.0,
+        "nickname_y": 0.0,
+        "invariant_x": 0.0,
+        "invariant_y": 0.0
+    },
+    "jorks":
+    [],
+    "sub_components":
+    [],
+    "edges":
+    [
+        {
+            "source_location": "Main€FischerAð1đ€L2",
+            "target_location": "Main€FischerAð1đ€L3",
+            "select": "",
+            "guard": "true",
+            "update": "",
+            "sync": "",
+            "nails":
+            []
+        },
+        {
+            "source_location": "Main€FischerAð1đ€L3",
+            "target_location": "Main€FischerAð1đ€L4",
+            "select": "",
+            "guard": "pubid == 0",
+            "update": "x :=  0;",
+            "sync": "",
+            "nails":
+            []
+        },
+        {
+            "source_location": "Main€FischerAð1đ€L5",
+            "target_location": "Main€FischerAð1đ€L6",
+            "select": "",
+            "guard": "pubid == 1 && counter == 0",
+            "update": "counter :=  counter +1 ;x :=  0;",
+            "sync": "",
+            "nails":
+            []
+        },
+        {
+            "source_location": "Main€FischerAð1đ€L4",
+            "target_location": "Main€FischerAð1đ€L5",
+            "select": "",
+            "guard": "x <= k",
+            "update": "pubid :=  1;",
+            "sync": "",
+            "nails":
+            []
+        },
+        {
+            "source_location": "Main€FischerAð1đ€L5",
+            "target_location": "Main€FischerAð1đ€L4",
+            "select": "",
+            "guard": "x > k && pubid != 1",
+            "update": "x :=  0;",
+            "sync": "",
+            "nails":
+            []
+        },
+        {
+            "source_location": "Main€FischerAð1đ€L6",
+            "target_location": "Main€FischerAð1đ€L3",
+            "select": "",
+            "guard": "true",
+            "update": "pubid :=  0 ;counter :=  counter -1;",
+            "sync": "",
+            "nails":
+            []
+        }
+    ],
+    "main": false,
+    "description": "AUTOMATICALLY GENERATED. DO NOT USE THIS",
+    "x": 0.0,
+    "y": 0.0,
+    "width": 0.0,
+    "height": 0.0,
+    "color": "7",
+    "include_in_periodic_check": false
+}

--- a/test/verification/fischer-2/Main€FischerBð2đ.json
+++ b/test/verification/fischer-2/Main€FischerBð2đ.json
@@ -1,1 +1,168 @@
-{"name":"Main€FischerBð2đ","declarations":"","locations":[{"id":"Main€FischerBð2đ€L3","nickname":"","invariant":"","type":"NORMAL","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0},{"id":"Main€FischerBð2đ€L4","nickname":"","invariant":"","type":"NORMAL","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0},{"id":"Main€FischerBð2đ€L5","nickname":"","invariant":"","type":"NORMAL","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0},{"id":"Main€FischerBð2đ€L6","nickname":"","invariant":"","type":"NORMAL","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0}],"initial_location": {"id":"Main€FischerBð2đ€L2","nickname":"","invariant":"","type":"INITIAL","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0},"final_location": {"id":"Main€FischerBð2đ€L8","nickname":"","invariant":"","type":"FINAl","urgency": "NORMAL","x": 0.0,"y": 0.0,"color": "7","nickname_x": 0.0,"nickname_y": 0.0,"invariant_x":0.0,"invariant_y":0.0},"jorks":[],"sub_components": [],"edges": [{"source_location": "Main€FischerBð2đ€L2","target_location": "Main€FischerBð2đ€L3","select":"","guard":"true","update":"","sync":"","nails": []},{"source_location": "Main€FischerBð2đ€L3","target_location": "Main€FischerBð2đ€L4","select":"","guard":"pubid == 0","update":"x :=  0;","sync":"","nails": []},{"source_location": "Main€FischerBð2đ€L5","target_location": "Main€FischerBð2đ€L6","select":"","guard":"pubid == 2","update":"counter :=  counter +1 ;x :=  0;","sync":"","nails": []},{"source_location": "Main€FischerBð2đ€L4","target_location": "Main€FischerBð2đ€L5","select":"","guard":"x <= k","update":"pubid :=  2;","sync":"","nails": []},{"source_location": "Main€FischerBð2đ€L5","target_location": "Main€FischerBð2đ€L4","select":"","guard":"x > k && pubid != 2","update":"x :=  0;","sync":"","nails": []},{"source_location": "Main€FischerBð2đ€L6","target_location": "Main€FischerBð2đ€L3","select":"","guard":"true","update":"pubid :=  0 ;counter :=  counter -1;","sync":"","nails": []}],"main":false,"description": "AUTOMATICALLY GENERATED. DO NOT USE THIS","x":0.0,"y":0.0,"width":0.0,"height":0.0,"color":"7","include_in_periodic_check":false}
+{
+    "name": "Main€FischerBð2đ",
+    "declarations": "",
+    "locations":
+    [
+        {
+            "id": "Main€FischerBð2đ€L3",
+            "nickname": "",
+            "invariant": "",
+            "type": "NORMAL",
+            "urgency": "NORMAL",
+            "x": 0.0,
+            "y": 0.0,
+            "color": "7",
+            "nickname_x": 0.0,
+            "nickname_y": 0.0,
+            "invariant_x": 0.0,
+            "invariant_y": 0.0
+        },
+        {
+            "id": "Main€FischerBð2đ€L4",
+            "nickname": "",
+            "invariant": "",
+            "type": "NORMAL",
+            "urgency": "NORMAL",
+            "x": 0.0,
+            "y": 0.0,
+            "color": "7",
+            "nickname_x": 0.0,
+            "nickname_y": 0.0,
+            "invariant_x": 0.0,
+            "invariant_y": 0.0
+        },
+        {
+            "id": "Main€FischerBð2đ€L5",
+            "nickname": "",
+            "invariant": "",
+            "type": "NORMAL",
+            "urgency": "NORMAL",
+            "x": 0.0,
+            "y": 0.0,
+            "color": "7",
+            "nickname_x": 0.0,
+            "nickname_y": 0.0,
+            "invariant_x": 0.0,
+            "invariant_y": 0.0
+        },
+        {
+            "id": "Main€FischerBð2đ€L6",
+            "nickname": "",
+            "invariant": "",
+            "type": "NORMAL",
+            "urgency": "NORMAL",
+            "x": 0.0,
+            "y": 0.0,
+            "color": "7",
+            "nickname_x": 0.0,
+            "nickname_y": 0.0,
+            "invariant_x": 0.0,
+            "invariant_y": 0.0
+        }
+    ],
+    "initial_location":
+    {
+        "id": "Main€FischerBð2đ€L2",
+        "nickname": "",
+        "invariant": "",
+        "type": "INITIAL",
+        "urgency": "NORMAL",
+        "x": 0.0,
+        "y": 0.0,
+        "color": "7",
+        "nickname_x": 0.0,
+        "nickname_y": 0.0,
+        "invariant_x": 0.0,
+        "invariant_y": 0.0
+    },
+    "final_location":
+    {
+        "id": "Main€FischerBð2đ€L8",
+        "nickname": "",
+        "invariant": "",
+        "type": "FINAl",
+        "urgency": "NORMAL",
+        "x": 0.0,
+        "y": 0.0,
+        "color": "7",
+        "nickname_x": 0.0,
+        "nickname_y": 0.0,
+        "invariant_x": 0.0,
+        "invariant_y": 0.0
+    },
+    "jorks":
+    [],
+    "sub_components":
+    [],
+    "edges":
+    [
+        {
+            "source_location": "Main€FischerBð2đ€L2",
+            "target_location": "Main€FischerBð2đ€L3",
+            "select": "",
+            "guard": "true",
+            "update": "",
+            "sync": "",
+            "nails":
+            []
+        },
+        {
+            "source_location": "Main€FischerBð2đ€L3",
+            "target_location": "Main€FischerBð2đ€L4",
+            "select": "",
+            "guard": "pubid == 0",
+            "update": "x :=  0;",
+            "sync": "",
+            "nails":
+            []
+        },
+        {
+            "source_location": "Main€FischerBð2đ€L5",
+            "target_location": "Main€FischerBð2đ€L6",
+            "select": "",
+            "guard": "pubid == 2 && counter == 0",
+            "update": "counter :=  counter +1 ;x :=  0;",
+            "sync": "",
+            "nails":
+            []
+        },
+        {
+            "source_location": "Main€FischerBð2đ€L4",
+            "target_location": "Main€FischerBð2đ€L5",
+            "select": "",
+            "guard": "x <= k",
+            "update": "pubid :=  2;",
+            "sync": "",
+            "nails":
+            []
+        },
+        {
+            "source_location": "Main€FischerBð2đ€L5",
+            "target_location": "Main€FischerBð2đ€L4",
+            "select": "",
+            "guard": "x > k && pubid != 2",
+            "update": "x :=  0;",
+            "sync": "",
+            "nails":
+            []
+        },
+        {
+            "source_location": "Main€FischerBð2đ€L6",
+            "target_location": "Main€FischerBð2đ€L3",
+            "select": "",
+            "guard": "true",
+            "update": "pubid :=  0 ;counter :=  counter -1;",
+            "sync": "",
+            "nails":
+            []
+        }
+    ],
+    "main": false,
+    "description": "AUTOMATICALLY GENERATED. DO NOT USE THIS",
+    "x": 0.0,
+    "y": 0.0,
+    "width": 0.0,
+    "height": 0.0,
+    "color": "7",
+    "include_in_periodic_check": false
+}

--- a/test/verification/fischer-2/Queries.json
+++ b/test/verification/fischer-2/Queries.json
@@ -1,12 +1,7 @@
 [
   {
-    "query": "E F counter \u003d\u003d 1",
+    "query": "E F counter > 1",
     "comment": "Can any processes get to CS?",
-    "is_periodic": false
-  },
-  {
-    "query": "E F Main€FischerA(1).L6 && Main€FischerB(2).L6",
-    "comment": "Can both processes get to the critical section at the same time?",
     "is_periodic": false
   }
 ]

--- a/test/verification/fischer-2/Queries.json
+++ b/test/verification/fischer-2/Queries.json
@@ -1,7 +1,27 @@
 [
   {
     "query": "E F counter > 1",
-    "comment": "Can any processes get to CS?",
+    "comment": "",
+    "is_periodic": false
+  },
+  {
+    "query": "E F counter < 0",
+    "comment": "",
+    "is_periodic": false
+  },
+  {
+    "query": "E F counter == 1",
+    "comment": "",
+    "is_periodic": false
+  },
+  {
+    "query": "E F deadlock",
+    "comment": "",
+    "is_periodic": false
+  },
+  {
+    "query": "E F Main€FischerA(1).L6 && Main€FischerB(2).L6",
+    "comment": "",
     "is_periodic": false
   }
 ]

--- a/test/verification/fischer-2/Queries.json
+++ b/test/verification/fischer-2/Queries.json
@@ -1,11 +1,11 @@
 [
   {
-    "query": "E F counter > 1",
+    "query": "A G ! (counter > 1)",
     "comment": "",
     "is_periodic": false
   },
   {
-    "query": "E F counter < 0",
+    "query": "A G ! (counter < 0)",
     "comment": "",
     "is_periodic": false
   },
@@ -15,12 +15,12 @@
     "is_periodic": false
   },
   {
-    "query": "E F deadlock",
+    "query": "A G ! deadlock",
     "comment": "",
     "is_periodic": false
   },
   {
-    "query": "E F Main€FischerA(1).L6 && Main€FischerB(2).L6",
+    "query": "A G !(Main€FischerA(1).L6 && Main€FischerB(2).L6)",
     "comment": "",
     "is_periodic": false
   }

--- a/test/verification/fischer-2/expected_results.ignore.txt
+++ b/test/verification/fischer-2/expected_results.ignore.txt
@@ -1,2 +1,5 @@
+E F counter > 1 : false
+E F counter < 0 : false
 E F counter == 1 : true
-E F Main€FischerA(1).L6 && Main€FischerB(2).L6 : true
+E F deadlock : false
+E F Main€FischerA(1).L6 && Main€FischerB(2).L6 : false

--- a/test/verification/fischer-2/expected_results.ignore.txt
+++ b/test/verification/fischer-2/expected_results.ignore.txt
@@ -1,5 +1,5 @@
-E F counter > 1 : false
-E F counter < 0 : false
+A G ! (counter > 1) : true
+A G ! (counter < 0) : true
 E F counter == 1 : true
-E F deadlock : false
-E F Main€FischerA(1).L6 && Main€FischerB(2).L6 : false
+A G ! deadlock : true
+A G ! (Main€FischerA(1).L6 && Main€FischerB(2).L6) : true


### PR DESCRIPTION
This MR fixes bugs related to:

 - Choices with overlapping update influence are still taken
 - Recursive state hashes (i.e. non-affecting tock transitions)
 - Fischer-2 test set queries and updates were wrongfully implemented
 - A G queries are now giving proper results Related Issue: https://github.com/sillydan1/AALTITOAD/issues/25 