### PR TITLE
Patch/correct cross edge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 # 3.16+ because of target_precompiled_header
 cmake_minimum_required(VERSION 3.16)
-project(aaltitoad VERSION 0.10.0)
+project(aaltitoad VERSION 0.10.1)
 configure_file(src/config.h.in config.h)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/src/cli/CLIConfig.cpp
+++ b/src/cli/CLIConfig.cpp
@@ -82,7 +82,6 @@ std::vector<option_t> CLIConfig::GetCLIOptionsOnly() {
     std::transform(cliOptions.begin(), cliOptions.end(),
                    std::back_inserter(output),
                    [](std::pair<option_requirement, option_t> element) -> option_t { return element.second; });
-    add_help_option(output);
     return output;
 }
 

--- a/src/verifier/ReachabilitySearcher.cpp
+++ b/src/verifier/ReachabilitySearcher.cpp
@@ -255,7 +255,7 @@ bool ReachabilitySearcher::ForwardReachabilitySearch(const nondeterminism_strate
         stateit = PickStateFromWaitingList(strategy);
     }
     spdlog::info("Found a negative result after searching: {0} states", Passed.size());
-    if(CLIConfig::getInstance()["verbosity"].as_integer() >= 6)
+    if(CLIConfig::getInstance()["verbosity"].as_integer_or_default(0) >= 6)
         debug_print_passed_list(*this);
     if(!CLIConfig::getInstance()["notrace"])
         return query_results.size() - PrintResults(query_results) == 0;

--- a/src/verifier/TTASuccessorGenerator.h
+++ b/src/verifier/TTASuccessorGenerator.h
@@ -26,11 +26,12 @@ public:
     /// Gets the set of states that are reachable in the given state (no tocking implications)
     static std::vector<TTA::StateChange> GetNextTickStates(const TTA& ttaStateAndGraph);
     /// Gets all the predicates
-    static std::vector<VariablePredicate> GetInterestingVariablePredicatesInState(const TTA& ttaState);
+    static std::vector<std::vector<VariablePredicate>> GetInterestingVariablePredicatesInState(const TTA& ttaState);
     /// A more efficient way of checking if the state is interesting, than getting an empty vector
     static bool IsStateInteresting(const TTA& ttaState);
     /// Finds and applies all available interesting predicates
     static std::vector<TTA::StateChange> GetNextTockStates(const TTA& ttaState);
+    static std::vector<TTA::StateChange> GetNextTockStatesFromPredicates(const std::vector<VariablePredicate>& predicates, const TTA::SymbolMap& symbols);
 
 private:
     static VariablePredicate ConvertFromGuardExpression(const TTA::GuardExpression& expressionTree, const TTA& ttaState);


### PR DESCRIPTION
This MR fixes an issue during tock-change evaluation, when there are multiple edges with guards containing external variables - then `GetNextTockStates` calculated _all changes combined_. This MR changes that, so each edge and guard expression is handled individually.

This should also cut down on the statespace explosion problem